### PR TITLE
Fixed a bug where the fieldtype selected a form by default.

### DIFF
--- a/formerly/fieldtypes/Formerly_FormFieldType.php
+++ b/formerly/fieldtypes/Formerly_FormFieldType.php
@@ -12,7 +12,9 @@ class Formerly_FormFieldType extends BaseFieldType
 	{
 		$forms = craft()->formerly_forms->getAllForms();
 
-		$options = array();
+		$options = array(
+			0 => '-- Select a form --'
+		);
 
 		foreach ($forms as $form)
 		{


### PR DESCRIPTION
The field type would always have a form selected, even if you didn't want a form on that entry. This adds a way to not select a form.