### PR TITLE
Field type and Export fixes

### DIFF
--- a/form.html
+++ b/form.html
@@ -1,3 +1,5 @@
+{% set form = craft.formerly.form(form) %}
+
 <form method="post" accept-charset="utf-8">
 	{{ getCsrfInput() }}
 	<input type="hidden" name="action" value="formerly/submissions/postSubmission">

--- a/formerly/controllers/Formerly_ExportController.php
+++ b/formerly/controllers/Formerly_ExportController.php
@@ -33,7 +33,27 @@ class Formerly_ExportController extends BaseController
 				$columnName = str_replace($form->handle . '_', '', $question->handle);
 				$columnName = ucwords($columnName);
 
-				$row[$columnName] = $submission->{$question->handle};
+				$value = $submission->{$question->handle};
+
+				if($value instanceof MultiOptionsFieldData)
+				{
+					$options = $value->getOptions();
+
+					$summary = array();
+
+					for ($j = 0; $j < count($options); ++$j)
+					{
+						$option = $options[$j];
+						if($option->selected)
+							$summary[] = $option->label;
+					}
+					$row[$columnName] = implode($summary, ', ');
+				}
+				else
+				{
+					$row[$columnName] = $value;
+				}
+
 			}
 
 			$data[] = $row;

--- a/formerly/fieldtypes/Formerly_FormFieldType.php
+++ b/formerly/fieldtypes/Formerly_FormFieldType.php
@@ -1,22 +1,43 @@
 <?php
+
 namespace Craft;
 
-class Formerly_FormFieldType extends BaseFieldType
+class Formerly_FormFieldType extends BaseOptionsFieldType
 {
+	// Public Methods
+	// =========================================================================
+
+	/**
+	 * @inheritDoc IComponentType::getName()
+	 *
+	 * @return string
+	 */
 	public function getName()
 	{
 		return Craft::t('Formerly Form');
 	}
 
+	/**
+	 * @inheritDoc IFieldType::getInputHtml()
+	 *
+	 * @param string $name
+	 * @param mixed  $value
+	 *
+	 * @return string
+	 */
 	public function getInputHtml($name, $value)
 	{
+
 		$forms = craft()->formerly_forms->getAllForms();
 
-		$options = array();
+		$options = array(array('label' => '','value' => ''));
 
 		foreach ($forms as $form)
 		{
-			$options[$form->handle] = $form->name;
+			$options[] = array(
+				'label' => $form->name,
+				'value' => $form->handle
+			);
 		}
 
 		return craft()->templates->render('_includes/forms/select', array(
@@ -24,10 +45,30 @@ class Formerly_FormFieldType extends BaseFieldType
 			'value'   => $value,
 			'options' => $options
 		));
+
 	}
 
-	public function prepValue($value)
+	/**
+	 * @inheritDoc BaseElementFieldType::getSettingsHtml()
+	 *
+	 * @return string|null
+	 */
+	public function getSettingsHtml()
 	{
-		return craft()->formerly_forms->getFormByHandle($value);
+		return false;
 	}
+
+	// Protected Methods
+	// =========================================================================
+
+	/**
+	 * @inheritDoc BaseOptionsFieldType::getOptionsSettingsLabel()
+	 *
+	 * @return string
+	 */
+	protected function getOptionsSettingsLabel()
+	{
+		return Craft::t('Formerly Form Options');
+	}
+
 }


### PR DESCRIPTION
Fixed the field type to now show what form was selected and converted the field type to extend BaseOptionsFieldType, added a default blank set of options for the first row and updated the example twig code to cope with not getting a Formerly_Form model.