### PR TITLE
fix default dropdown field select

### DIFF
--- a/formerly/fieldtypes/Formerly_FormFieldType.php
+++ b/formerly/fieldtypes/Formerly_FormFieldType.php
@@ -12,7 +12,9 @@ class Formerly_FormFieldType extends BaseFieldType
 	{
 		$forms = craft()->formerly_forms->getAllForms();
 
-		$options = array();
+		$options = array(
+			0 => '-- Select a form --'
+		);
 
 		foreach ($forms as $form)
 		{
@@ -21,7 +23,7 @@ class Formerly_FormFieldType extends BaseFieldType
 
 		return craft()->templates->render('_includes/forms/select', array(
 			'name'    => $name,
-			'value'   => $value,
+			'value'   => (get_class($value) == 'Craft\Formerly_FormModel') ? $value->handle : null,
 			'options' => $options
 		));
 	}


### PR DESCRIPTION
This commit fixes the default selected value in an entry type with a 'Formerly Form' field.

Previously, the first Formerly Form was selected on load, which forced the user to always reselect the proper form when updating the entry.

An empty option has also been added to the dropdown if the user doesn't want to select a form for a given locale.