### PR TITLE
Store the queried form in a class member once it is fetched. 

### DIFF
--- a/formerly/models/Formerly_SubmissionModel.php
+++ b/formerly/models/Formerly_SubmissionModel.php
@@ -5,6 +5,11 @@ class Formerly_SubmissionModel extends BaseElementModel
 {
 	protected $elementType = 'Formerly_Submission';
 
+	/**
+	 * @var Formerly_FormModel
+	 */
+	protected $formModel;
+
 	protected function defineAttributes()
 	{
 		return array_merge(parent::defineAttributes(), array(
@@ -37,12 +42,17 @@ class Formerly_SubmissionModel extends BaseElementModel
 		}
 	}
 
+	/**
+	 * @return Formerly_FormModel
+	 */
 	public function getForm()
 	{
-		if ($this->formId)
+		if (!$this->formModel && $this->formId)
 		{
-			return craft()->formerly_forms->getFormById($this->formId);
+			$this->formModel = craft()->formerly_forms->getFormById($this->formId);
 		}
+
+		return $this->formModel;
 	}
 
 	public function downloadLink($handle) {


### PR DESCRIPTION
This prevents unnecessary queries to the database, and allows to modify the form object at runtime in an event. For example, we wanted to have a dynamic "to" field for outgoing e-mails, based on the value from an entry. We tried to modify the to address dynamically in the triggered event, but the change was overwritten because the form object was fetched again from the database. This change fixed that.