### PR TITLE
Allows for uploaded files to be accessed outside of the public directory

### DIFF
--- a/controllers/Formerly_SubmissionsController.php
+++ b/controllers/Formerly_SubmissionsController.php
@@ -49,7 +49,10 @@ class Formerly_SubmissionsController extends BaseController
 
 			$asset = craft()->assets->getFileById($fileId);
 
-			$data = file_get_contents( $asset->url );
+			$serverPath = $asset->source->attributes['settings']['path'];
+
+			$data = file_get_contents( $serverPath . $asset->filename );
+
 			header("Content-type: " . $asset->mimeType );
 			header("Content-disposition: attachment;filename=" . $asset->filename);
 
@@ -58,6 +61,7 @@ class Formerly_SubmissionsController extends BaseController
 
 		return;
 	}
+
 
 	public function actionPostSubmission()
 	{


### PR DESCRIPTION
Instead of accessing the uploaded file via the file_get_contents function using a public URL, this allows for secure documents to be accessed via the absolute path (ie. files that you can't access via a public url). Eg: Job applications etc, with sensitive data.