### PR TITLE
Support actions on index page

### DIFF
--- a/templates/submissions/_index.html
+++ b/templates/submissions/_index.html
@@ -14,17 +14,10 @@
 {% includeJsResource 'formerly/formerly.js' %}
 
 {% block initJs %}
-	Craft.elementIndex = Craft.createElementIndex('{{ elementTypeClass }}', $('#main'), {
-	context:        '{{ context }}',
-	showStatusMenu: {{ showStatusMenu is defined ? showStatusMenu|json_encode|raw : "'auto'" }},
-	showLocaleMenu: {{ showLocaleMenu is defined ? showLocaleMenu|json_encode|raw : "'auto'" }},
-	storageKey:     'elementindex.{{ elementTypeClass }}',
-	criteria:       { localeEnabled: null },
-	});
+	{{ parent() }}
 
 	{% if craft.request.getParam('sourceKey') %}
 		Craft.elementIndex.selectSource($('a[data-key="{{  craft.request.getParam('sourceKey') }}"]'));
 		Craft.elementIndex.updateElements();
 	{% endif %}
-
 {% endblock %}


### PR DESCRIPTION
The submissions index page doesn't support Craft actions. I would like to be able to extend Formerly to add additional actions from the admin interface.

As a part of this update, I refactored the delete link to be consistent with how the Entries page works.

Because addEntryActions is a global hook, I switched the Formerly sources to be prefixed, which is consistent with EntryElementType. There, it uses "singles" or "section:id".