### PR TITLE
fix undefined variable warning

### DIFF
--- a/services/Formerly_SubmissionsService.php
+++ b/services/Formerly_SubmissionsService.php
@@ -33,6 +33,8 @@ class Formerly_SubmissionsService extends BaseApplicationComponent
 			$submission = craft()->elements->getElementById($submission->id, 'Formerly_Submission');
 
 			$this->sendSubmissionEmails($submission);
+			
+			$success = true;
 
 			// Send mailchimp submission
 			$form = craft()->formerly_forms->getFormById($submission->formId);
@@ -54,7 +56,6 @@ class Formerly_SubmissionsService extends BaseApplicationComponent
                 $api = new \MCAPI($apiKey);
                 $api->listSubscribe($list, $vars['EMAIL'], $vars, 'html', false);
 
-                $success = true;
                 if ($api->errorCode) {
                     $success = false;
                 }


### PR DESCRIPTION
Undefined variable: success (/var/www/html/[...]/craft/plugins/formerly/services/Formerly_SubmissionsService.php:67)
The variable $success raise a warning since  outside of the mailchimp if statement it is not defined, while it is returned at the end of the method.